### PR TITLE
Update example to get correct file extension

### DIFF
--- a/python/facemask/fm.py
+++ b/python/facemask/fm.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
 
     # parse our command-line argument
     file_name = (sys.argv[-1])
-    extension = file_name.split(".")[1]
+    extension = file_name.split(".")[-1]
 
     # encode our image as base64
     with open(file_name, "rb") as img:


### PR DESCRIPTION
There may be directories having '.' inside their names, in which case this script breaks the API, hence fetching the last split